### PR TITLE
Update automation workflow to use ghcr.io

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -10,23 +10,23 @@ on:
       - '.github/**'
 
 jobs:
+
   docker:
     runs-on: ubuntu-latest
     steps:
+
       - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1.6.0
 
-      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - name: Login to GitHub container registry
+        uses: docker/login-action@6af3c118c8376c675363897acf1757f7a9be6583
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare Build
         id: prepare-build
@@ -38,74 +38,51 @@ jobs:
               echo "::set-output name=environment::dev";
             fi
 
+      # TODO: maybe we can use a build matrix for parallel builds
+      # About the cache:
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
       - name: Build NGINX Docker Image
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
-          push: false
-          load: true
+          push: true
           build-args:
             "VERSION=${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
           tags: package-health/nginx:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}
           file: ./docker/nginx.Dockerfile
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build PHP-FPM Docker Image
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
-          push: false
-          load: true
+          push: true
           build-args:
             "VERSION=${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
           tags: package-health/php-fpm:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}
           file: ./docker/php.Dockerfile
           target: fpm
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build PHP-CLI Docker Image
-        uses: docker/build-push-action@v2.10.0
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
-          push: false
-          load: true
+          push: true
           build-args:
             "VERSION=${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
           tags: package-health/php-cli:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}
           file: ./docker/php.Dockerfile
           target: cli
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Generate Image Hashsum
-        run: |
-          docker save "package-health/nginx:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}" | gzip > "nginx-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz"
-          sha1sum "nginx-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz" > "nginx-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz.sha1"
-          docker save "package-health/php-fpm:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}" | gzip > "php-fpm-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz"
-          sha1sum "php-fpm-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz" > "php-fpm-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz.sha1"
-          docker save "package-health/php-cli:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}" | gzip > "php-cli-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz"
-          sha1sum "php-cli-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz" > "php-cli-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz.sha1"
-
-      - name: Create Release
+      - name: Create release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
           name: "php.package.health ${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
           tag_name: "${{ steps.prepare-build.outputs.environment }}@${{ steps.prepare-build.outputs.short }}"
           target_commitish: ${{ github.sha }}
-          files: |
-            nginx-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz
-            nginx-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz.sha1
-            php-fpm-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz
-            php-fpm-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz.sha1
-            php-cli-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz
-            php-cli-${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}.tar.gz.sha1
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          generate_release_notes: true


### PR DESCRIPTION
This changes the workflow to publish all built Docker images
directly to the GitHub container registry. This will make
it easier to deploy updates using an authenticated Docker daemon.

I've also changed the cache mode to use the experimental 'gha'
(GitHub actions) cache.