### PR TITLE
Add GitHub token permissions for automation tasks

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -13,6 +13,10 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
     steps:
 
       - name: Clone repository


### PR DESCRIPTION
The GitHub token will be used to push packages (actually,
Docker containers) and also to create release notes on every
workflow run.

This permission is scoped for the `docker:` job only.