### PR TITLE
Improve the execution scope of release workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -8,6 +8,7 @@ on:
       - 'develop'
     paths-ignore:
       - '.github/**'
+      - '**.md'
 
 jobs:
 


### PR DESCRIPTION
Don't run the workflow on changes to .md files

Syntax retrieved from this section:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths