### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -94,6 +94,7 @@ jobs:
           generate_release_notes: true
 
       - name: Send update to infrastructure repository
+        if: ${{ github.ref_type == 'tag' || github.ref_name != 'main' }}
         uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5
         with:
           # personal access token with "repo" scope

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -94,7 +94,6 @@ jobs:
           generate_release_notes: true
 
       - name: Send update to infrastructure repository
-        if: ${{ github.ref_type == 'tag' }}
         uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5
         with:
           # personal access token with "repo" scope


### PR DESCRIPTION
Hi :wave: 

This PR changes the logic of the release workflow.

16a2ed6eb2503f01d3c83ddbf7f30d5dc3c7f75b was picked due to a rebase from the `main` branch ( #60 was merged to `main`, before the default branch changed to `develop`).

1ea2b10653e11b75d9186fcb8f2392ed71a88e6f is the actual commit. The new logic goes like this:

For any branches other than `main`, the result of `steps.prepare-build.outputs.environment` will be `dev`, so we notify a deployment trigger to the development infrastructure. If the branch is `main`, but there is no tag, the container will be built, but nothing else should happen. Whenever there is a tagged push, a GH release will be created and we will notify the deployment of production infrastructure.

TL;DR non-tagged pushes on any branch except `main` should trigger a `dev` deployment. Assuming tagged pushes only happen based on `main` refs, then we trigger a `prod` deployment.

More info on GH conditionals: [link](https://docs.github.com/en/actions/learn-github-actions/expressions).