### PR TITLE
Add TruffleHog secret scan workflow

### DIFF
--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,19 @@
+name: Secret scan
+
+on: [pull_request]
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+
+      - name: Scan code for hardcoded secrets
+        uses: trufflesecurity/trufflehog@43955b9a38e09ac13194d10aff449b5fc9c238e4
+        with:
+          path: ./
+          base: ${{ github.base_ref }}
+          head: HEAD


### PR DESCRIPTION
This PR adds a new workflow: secret scan with TruffleHog. It is based on [this example](https://github.com/trufflesecurity/trufflehog#trufflehog-oss-github-action) from the project's documentation.

Regarding the `base:` argument: in the official docs, they use `${{ github.event.repository.default_branch }}`, which will scan your whole default branch (all commits since the beginning of the universe) for secrets. If we use it like that, and a secret is already present in the default branch, the action will fail until that branch is rewritten and the secrets are removed. In this PR, I'm using `${{ github.base_ref}}`, which makes the scan happen only for your commits on that PR.

I did check the repository locally and it found no secrets, so any of the two options is OK, I guess. Up to @flavioheleno to decide.

Command I used to check the repository (based on the [action setup](https://github.com/trufflesecurity/trufflehog/blob/fc18a5ae0c5ce05c4854928e04c080ea6164f33a/action.yml#L20-L28)): `docker run --rm --workdir=/data -v "${PWD}":/data ghcr.io/trufflesecurity/trufflehog:latest git file://./ --since-commit develop --branch HEAD --fail`. I also tested with `main`.