### PR TITLE
Add Docker to dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # Maintain dependencies for Dockerfiles
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,18 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "12:00"
 
   # Maintain dependencies for PHP Packages
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "12:00"
 
   # Maintain dependencies for Dockerfiles
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
       interval: "daily"
+      time: "12:00"


### PR DESCRIPTION
This PR has 2 commits:

1. Add Docker to the dependabot update checks.
2. Use a fixed time (9AM UTC -3) for dependabot checks/PRs.

The fixed time is already used in infrastructure repos.