### PR TITLE
Use a build matrix for Docker workflows

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -19,6 +19,19 @@ jobs:
     permissions:
       contents: write
       packages: write
+    strategy:
+      matrix:
+        service: [nginx, php-fpm, php-cli]
+        include:
+          - service: nginx
+            target: nginx
+            dockerfile: nginx.Dockerfile
+          - service: php-fpm
+            target: fpm
+            dockerfile: php.Dockerfile
+          - service: php-cli
+            target: cli
+            dockerfile: php.Dockerfile
 
     steps:
 
@@ -48,40 +61,15 @@ jobs:
       # TODO: maybe we can use a build matrix for parallel builds
       # About the cache:
       # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
-      - name: Build NGINX Docker Image
+      - name: Build ${{ matrix.service }} Docker Image
         uses: docker/build-push-action@1cb9d22b932e4832bb29793b7777ec860fc1cde0
         with:
           push: true
           build-args:
             "VERSION=${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
-          tags: ghcr.io/package-health/nginx:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}
-          file: ./docker/nginx.Dockerfile
-          context: .
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build PHP-FPM Docker Image
-        uses: docker/build-push-action@1cb9d22b932e4832bb29793b7777ec860fc1cde0
-        with:
-          push: true
-          build-args:
-            "VERSION=${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
-          tags: ghcr.io/package-health/php-fpm:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}
-          file: ./docker/php.Dockerfile
-          target: fpm
-          context: .
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build PHP-CLI Docker Image
-        uses: docker/build-push-action@1cb9d22b932e4832bb29793b7777ec860fc1cde0
-        with:
-          push: true
-          build-args:
-            "VERSION=${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
-          tags: ghcr.io/package-health/php-cli:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}
-          file: ./docker/php.Dockerfile
-          target: cli
+          tags: ghcr.io/package-health/${{ matrix.service }}:${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}
+          file: ./docker/${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -17,8 +17,10 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       packages: write
+    outputs:
+      environment: ${{ steps.prepare-build.outputs.environment }}
+      shorthash: ${{ steps.prepare-build.outputs.short }}
     strategy:
       matrix:
         service: [nginx, php-fpm, php-cli]
@@ -35,6 +37,16 @@ jobs:
 
     steps:
 
+      - name: Prepare build variables
+        id: prepare-build
+        run: |
+            echo "::set-output name=short::${GITHUB_SHA:0:7}"
+            if [[ "${{ github.ref_name }}" == "main" ]]; then
+              echo "::set-output name=environment::prod"
+            else
+              echo "::set-output name=environment::dev"
+            fi
+
       - name: Clone repository
         uses: actions/checkout@v3
 
@@ -48,17 +60,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare Build
-        id: prepare-build
-        run: |
-            echo "::set-output name=short::$(git rev-parse --short HEAD)"
-            if [[ "${{ github.ref_name }}" == "main" ]]; then
-              echo "::set-output name=environment::prod"
-            else
-              echo "::set-output name=environment::dev"
-            fi
-
-      # TODO: maybe we can use a build matrix for parallel builds
       # About the cache:
       # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api
       - name: Build ${{ matrix.service }} Docker Image
@@ -74,19 +75,26 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Create release
-        if: ${{ github.ref_type == 'tag' }}
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
-        with:
-          name: "php.package.health ${{ steps.prepare-build.outputs.environment }}-${{ steps.prepare-build.outputs.short }}"
-          generate_release_notes: true
+  release-deploy:
+    needs: docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
-      - name: Send update to infrastructure repository
-        if: ${{ github.ref_type == 'tag' || github.ref_name != 'main' }}
-        uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5
-        with:
-          # personal access token with "repo" scope
-          token: ${{ secrets.INFRA_REPO_ACCESS_TOKEN }}
-          repository: package-health/infra-service
-          event-type: deploy-new-version
-          client-payload: '{"sha": "${{ github.sha }}", "environment": "${{ steps.prepare-build.outputs.environment }}"}'
+    steps:
+    - name: Create release
+      if: ${{ github.ref_type == 'tag' }}
+      uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+      with:
+        name: "php.package.health ${{ needs.docker.outputs.environment }}-${{ needs.docker.outputs.shorthash }}"
+        generate_release_notes: true
+
+    - name: Send update to infrastructure repository
+      if: ${{ github.ref_type == 'tag' || github.ref_name != 'main' }}
+      uses: peter-evans/repository-dispatch@11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5
+      with:
+        # personal access token with "repo" scope
+        token: ${{ secrets.INFRA_REPO_ACCESS_TOKEN }}
+        repository: package-health/infra-service
+        event-type: deploy-new-version
+        client-payload: '{"sha": "${{ github.sha }}", "environment": "${{ needs.docker.outputs.environment }}"}'

--- a/docker/nginx.Dockerfile
+++ b/docker/nginx.Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.23-alpine
+FROM nginx:1.23-alpine as nginx
 
 # https://blog.packagecloud.io/eng/2017/02/21/set-environment-variable-save-thousands-of-system-calls/
 ENV TZ=:/etc/localtime


### PR DESCRIPTION
Hi :wave: 

In this PR I've made two changes:

#### 1. Added a build matrix to Docker builds

I had to change `nginx.Dockerfile` in order to accommodate the build target argument. The matrix is built with configuration expansion ([doc](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations)). 

#### 2. Split the workflow in two

This is a revert of https://github.com/package-health/php/commit/65a5997b95ac4746e6d1d126086e240bc78e6e2c, because we don't want to trigger the release/deploy task for all matrix configurations. The job will run only once, after all builds are completed with success.

---

You can check an example of the workflow in this manually triggered run: https://github.com/package-health/php/actions/runs/2762273790