### PR TITLE
Add image.source annotation keys to Dockerfiles

### DIFF
--- a/docker/nginx.Dockerfile
+++ b/docker/nginx.Dockerfile
@@ -40,6 +40,7 @@ LABEL maintainer="Flavio Heleno <flaviohbatista@gmail.com>" \
       org.opencontainers.image.url="https://github.com/package-health/php" \
       org.opencontainers.image.vendor="Package Health" \
       org.opencontainers.image.version="${VERSION}" \
-      org.opencontainers.image.base.name="ghcr.io/package-health/pph-nginx:${VERSION}"
+      org.opencontainers.image.base.name="ghcr.io/package-health/pph-nginx:${VERSION}" \
+      org.opencontainers.image.source="https://github.com/package-health/php"
 
 WORKDIR /usr/share/nginx/html

--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -157,7 +157,8 @@ LABEL maintainer="Flavio Heleno <flaviohbatista@gmail.com>" \
       org.opencontainers.image.url="https://github.com/package-health/php" \
       org.opencontainers.image.vendor="Package Health" \
       org.opencontainers.image.version="${VERSION}" \
-      org.opencontainers.image.base.name="ghcr.io/package-health/pph-php-cli:${VERSION}"
+      org.opencontainers.image.base.name="ghcr.io/package-health/pph-php-cli:${VERSION}" \
+      org.opencontainers.image.source="https://github.com/package-health/php"
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["php"]
@@ -255,7 +256,8 @@ LABEL maintainer="Flavio Heleno <flaviohbatista@gmail.com>" \
       org.opencontainers.image.url="https://github.com/package-health/php" \
       org.opencontainers.image.vendor="Package Health" \
       org.opencontainers.image.version="${VERSION}" \
-      org.opencontainers.image.base.name="ghcr.io/package-health/pph-php-fpm:${VERSION}"
+      org.opencontainers.image.base.name="ghcr.io/package-health/pph-php-fpm:${VERSION}" \
+      org.opencontainers.image.source="https://github.com/package-health/php"
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["php-fpm"]


### PR DESCRIPTION
As described in the package settings:

![screenshot](https://user-images.githubusercontent.com/74891301/181817180-db9cd6a8-f87a-47e9-b488-b1b51f6cbd03.png)


Link to docs [here](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)