### PR TITLE
Revert trufflehog action to version 3.6.11

### DIFF
--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan code for hardcoded secrets
-        uses: trufflesecurity/trufflehog@047e2b4607487da3c05564ec9b198cf22a048310
+        uses: trufflesecurity/trufflehog@0752503872c81fb8820085d38d5cd7e7cff8a5af
         with:
           path: ./
           base: ${{ github.base_ref }}


### PR DESCRIPTION
Version 3.7.1 is failing:
https://github.com/trufflesecurity/trufflehog/issues/690

@flavioheleno FYI