### PR TITLE
Add paths used by packagist updates to Dockerfile

### DIFF
--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -118,6 +118,9 @@ COPY --chown=www-data:www-data --from=builder /usr/src/vendor/ /var/www/html/ven
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20210902 /usr/local/lib/php/extensions/no-debug-non-zts-20210902
 COPY --from=builder /usr/local/etc/php/conf.d/*.ini /usr/local/etc/php/conf.d/
 
+RUN mkdir /var/www/html/run && \
+    chown -R www-data:www-data /var/www/html/run
+
 #============================================
 # Library dependencies
 #============================================


### PR DESCRIPTION
If we don't add + change the path permissions here, when a
Docker bind-mount is made, the path will be created and owned
by root, thus failing future commands like mkdir, which is used
by the packagist task under user www-data

---

Not 100% pretty, but it works :smile: 