### PR TITLE
Add action caching

### DIFF
--- a/src/Application/Action/AbstractAction.php
+++ b/src/Application/Action/AbstractAction.php
@@ -5,6 +5,7 @@ namespace PackageHealth\PHP\Application\Action;
 
 use PackageHealth\PHP\Domain\Exception\DomainRecordNotFoundException;
 use PackageHealth\PHP\Domain\Exception\DomainValidationException;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -15,6 +16,7 @@ use Slim\HttpCache\CacheProvider;
 abstract class AbstractAction {
   protected LoggerInterface $logger;
   protected CacheProvider $cacheProvider;
+  protected CacheItemPoolInterface $cacheItemPool;
   protected ServerRequestInterface $request;
   protected ResponseInterface $response;
 
@@ -23,9 +25,14 @@ abstract class AbstractAction {
    */
   protected array $args;
 
-  public function __construct(LoggerInterface $logger, CacheProvider $cacheProvider) {
+  public function __construct(
+    LoggerInterface $logger,
+    CacheProvider $cacheProvider,
+    CacheItemPoolInterface $cacheItemPool
+  ) {
     $this->logger        = $logger;
     $this->cacheProvider = $cacheProvider;
+    $this->cacheItemPool = $cacheItemPool;
   }
 
   /**

--- a/src/Application/Action/Package/AbstractPackageAction.php
+++ b/src/Application/Action/Package/AbstractPackageAction.php
@@ -5,6 +5,7 @@ namespace PackageHealth\PHP\Application\Action\Package;
 
 use PackageHealth\PHP\Application\Action\AbstractAction;
 use PackageHealth\PHP\Domain\Package\PackageRepositoryInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Slim\HttpCache\CacheProvider;
 
@@ -14,9 +15,10 @@ abstract class AbstractPackageAction extends AbstractAction {
   public function __construct(
     LoggerInterface $logger,
     CacheProvider $cacheProvider,
+    CacheItemPoolInterface $cacheItemPool,
     PackageRepositoryInterface $packageRepository
   ) {
-    parent::__construct($logger, $cacheProvider);
+    parent::__construct($logger, $cacheProvider, $cacheItemPool);
     $this->packageRepository = $packageRepository;
   }
 }

--- a/src/Application/Action/Package/RedirectPackageAction.php
+++ b/src/Application/Action/Package/RedirectPackageAction.php
@@ -7,6 +7,7 @@ use PackageHealth\PHP\Domain\Package\PackageNotFoundException;
 use PackageHealth\PHP\Domain\Package\PackageRepositoryInterface;
 use PackageHealth\PHP\Domain\Package\PackageValidator;
 use PackageHealth\PHP\Domain\Version\VersionRepositoryInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Slim\HttpCache\CacheProvider;
@@ -19,10 +20,11 @@ final class RedirectPackageAction extends AbstractPackageAction {
   public function __construct(
     LoggerInterface $logger,
     CacheProvider $cacheProvider,
+    CacheItemPoolInterface $cacheItemPool,
     PackageRepositoryInterface $packageRepository,
     VersionRepositoryInterface $versionRepository
   ) {
-    parent::__construct($logger, $cacheProvider, $packageRepository);
+    parent::__construct($logger, $cacheProvider, $cacheItemPool, $packageRepository);
     $this->versionRepository = $versionRepository;
   }
 
@@ -33,97 +35,106 @@ final class RedirectPackageAction extends AbstractPackageAction {
     $project = $this->resolveStringArg('project');
     PackageValidator::assertValidProject($project);
 
-    $packageCol = $this->packageRepository->find(
-      [
-        'name' => "{$vendor}/{$project}"
-      ],
-      1
-    );
-
-    if ($packageCol->isEmpty()) {
-      throw new PackageNotFoundException();
-    }
-
-    $routeParser = RouteContext::fromRequest($this->request)->getRouteParser();
-
-    $package = $packageCol->first();
-    if ($package->getLatestVersion() === '') {
-      $versionCol = $this->versionRepository->find(
+    $item = $this->cacheItemPool->getItem("/view/redirectPackage/{$vendor}/{$project}");
+    $url  = $item->get();
+    if ($item->isHit() === false) {
+      $packageCol = $this->packageRepository->find(
         [
-          'package_id' => $package->getId()
-        ]
+          'name' => "{$vendor}/{$project}"
+        ],
+        1
       );
 
-      if (count($versionCol)) {
-        $release = $versionCol->last();
-        $this->logger->debug(
-          sprintf(
-            'Package "%s" is being redirected to "%s"',
-            $package->getName(),
-            $release->getNumber()
-          )
+      if ($packageCol->isEmpty()) {
+        throw new PackageNotFoundException();
+      }
+
+      $package = $packageCol->first();
+
+      $routeParser = RouteContext::fromRequest($this->request)->getRouteParser();
+
+      if ($package->getLatestVersion() === '') {
+        $versionCol = $this->versionRepository->find(
+          [
+            'package_id' => $package->getId()
+          ]
         );
 
-        return $this->respondWithRedirect(
-          $routeParser->urlFor(
-            'viewPackage',
+        if (count($versionCol)) {
+          $release = $versionCol->last();
+          $this->logger->debug(
+            sprintf(
+              'Package "%s" is being redirected to "%s"',
+              $package->getName(),
+              $release->getNumber()
+            )
+          );
+
+          return $this->respondWithRedirect(
+            $routeParser->urlFor(
+              'viewPackage',
+              [
+                'vendor'  => $vendor,
+                'project' => $project,
+                'version' => $release->getNumber()
+              ]
+            )
+          );
+        }
+
+        $twig = Twig::fromRequest($this->request);
+
+        return $this->respondWithHtml(
+          $twig->fetch(
+            'package.twig',
             [
-              'vendor'  => $vendor,
-              'project' => $project,
-              'version' => $release->getNumber()
+              'status'          => [
+                'type' => 'is-dark'
+              ],
+              'package'         => $package,
+              'version'         => [],
+              'requiredDeps'    => [],
+              'requiredDevDeps' => [],
+              'notification' => [
+                'type' => 'is-warning',
+                'message' => 'This package has no public releases.'
+              ],
+              'show' => [
+                'hero' => [
+                  'subtitle' => false,
+                  'footer'   => false
+                ]
+              ],
+              'app' => [
+                'version' => $_ENV['VERSION']
+              ]
             ]
           )
         );
       }
 
-      $twig = Twig::fromRequest($this->request);
-
-      return $this->respondWithHtml(
-        $twig->fetch(
-          'package.twig',
-          [
-            'status'          => [
-              'type' => 'is-dark'
-            ],
-            'package'         => $package,
-            'version'         => [],
-            'requiredDeps'    => [],
-            'requiredDevDeps' => [],
-            'notification' => [
-              'type' => 'is-warning',
-              'message' => 'This package has no public releases.'
-            ],
-            'show' => [
-              'hero' => [
-                'subtitle' => false,
-                'footer'   => false
-              ]
-            ],
-            'app' => [
-              'version' => $_ENV['VERSION']
-            ]
-          ]
+      $this->logger->debug(
+        sprintf(
+          'Package "%s" is being redirected to "%s"',
+          $package->getName(),
+          $package->getLatestVersion()
         )
       );
-    }
-
-    $this->logger->debug(
-      sprintf(
-        'Package "%s" is being redirected to "%s"',
-        $package->getName(),
-        $package->getLatestVersion()
-      )
-    );
-
-    return $this->respondWithRedirect(
-      $routeParser->urlFor(
+      $url = $routeParser->urlFor(
         'viewPackage',
         [
           'vendor'  => $vendor,
           'project' => $project,
           'version' => $package->getLatestVersion()
         ]
-      )
-    );
+      );
+
+      $item->set($url);
+      $item->expiresAfter(3600);
+
+      $this->cacheItemPool->save($item);
+    }
+
+    return $this->respondWithRedirect($url);
   }
 }

--- a/src/Application/Action/Package/ViewPackageAction.php
+++ b/src/Application/Action/Package/ViewPackageAction.php
@@ -12,6 +12,7 @@ use PackageHealth\PHP\Domain\Version\VersionNotFoundException;
 use PackageHealth\PHP\Domain\Version\VersionRepositoryInterface;
 use PackageHealth\PHP\Domain\Version\VersionStatusEnum;
 use PackageHealth\PHP\Domain\Version\VersionValidator;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Slim\HttpCache\CacheProvider;
@@ -24,11 +25,12 @@ final class ViewPackageAction extends AbstractPackageAction {
   public function __construct(
     LoggerInterface $logger,
     CacheProvider $cacheProvider,
+    CacheItemPoolInterface $cacheItemPool,
     PackageRepositoryInterface $packageRepository,
     DependencyRepositoryInterface $dependencyRepository,
     VersionRepositoryInterface $versionRepository
   ) {
-    parent::__construct($logger, $cacheProvider, $packageRepository);
+    parent::__construct($logger, $cacheProvider, $cacheItemPool, $packageRepository);
     $this->dependencyRepository = $dependencyRepository;
     $this->versionRepository    = $versionRepository;
   }
@@ -43,223 +45,227 @@ final class ViewPackageAction extends AbstractPackageAction {
     $version = $this->resolveStringArg('version');
     VersionValidator::assertValid($version);
 
-    $twig = Twig::fromRequest($this->request);
+    $item = $this->cacheItemPool->getItem("/view/viewPackage/{$vendor}/{$project}/{$version}");
+    $html = $item->get();
+    if ($item->isHit() === false) {
+      $twig = Twig::fromRequest($this->request);
 
-    $packageCol = $this->packageRepository->find(
-      [
-        'name' => "{$vendor}/{$project}"
-      ],
-      1
-    );
-
-    if ($packageCol->isEmpty()) {
-      throw new PackageNotFoundException();
-    }
-
-    $package = $packageCol->first();
-
-    $versionCol = $this->versionRepository->find(
-      [
-        'package_id' => $package->getId(),
-        'number'     => $version
-      ],
-      1
-    );
-
-    if ($versionCol->isEmpty()) {
-      throw new VersionNotFoundException(
-        sprintf(
-          'Version "%s" was not found. Was that release tagged?',
-          $version
-        )
-      );
-    }
-
-    $release = $versionCol->first();
-
-    $reqDependencies = $this->dependencyRepository->find(
-      [
-        'version_id'  => $release->getId(),
-        'development' => false
-      ]
-    );
-
-    $devDependencies = $this->dependencyRepository->find(
-      [
-        'version_id'  => $release->getId(),
-        'development' => true
-      ]
-    );
-
-    $this->logger->debug("Package '{$vendor}/{$project}:{$version}' was viewed.");
-
-    $lastModified = $package->getUpdatedAt() ?? $package->getCreatedAt();
-    $this->response = $this->cacheProvider->withLastModified(
-      $this->response,
-      $lastModified->getTimestamp()
-    );
-    $this->response = $this->cacheProvider->withEtag(
-      $this->response,
-      hash('sha1', (string)$lastModified->getTimestamp())
-    );
-
-    $data = [
-      'status' => [
-        'type' => ''
-      ],
-      'package' => $package,
-      'version' => $release,
-      'requiredDeps' => [],
-      'requiredDepsSubtitle' => '',
-      'requiredDevDeps' => [],
-      'requiredDevDepsSubtitle' => '',
-      'show' => [
-        'hero' => [
-          'footer' => true,
-        ],
-        'navbar' => [
-          'menu' => true
-        ]
-      ],
-      'app' => [
-        'version' => $_ENV['VERSION']
-      ]
-    ];
-
-    $data['status']['type'] = match ($release->getStatus()) {
-      VersionStatusEnum::UpToDate => 'is-success',
-      VersionStatusEnum::NoDeps => 'is-success',
-      VersionStatusEnum::Outdated => 'is-warning',
-      VersionStatusEnum::Insecure => 'is-danger',
-      VersionStatusEnum::MaybeInsecure => 'is-warning',
-      VersionStatusEnum::Unknown => 'is-dark'
-    };
-
-    $subtitle = [];
-    foreach ($reqDependencies as $dependency) {
       $packageCol = $this->packageRepository->find(
         [
-          'name' => $dependency->getName()
+          'name' => "{$vendor}/{$project}"
         ],
         1
       );
 
-      // handle unregistered dependencies
-      $unregistered = $packageCol->isEmpty();
-      $dependencyPackage = match ($packageCol->isEmpty()) {
-        true  => [
-          'name' => $dependency->getName()
-        ],
-        false => $packageCol->first()
-      };
-
-      $data['requiredDeps'][] = [
-        'package' => $dependencyPackage,
-        'requiredVersion' => $dependency->getConstraint(),
-        'unregistered' => $unregistered,
-        'status' => [
-          'type' => $dependency->getStatus()->getColor(),
-          'text' => $dependency->getStatus()->getLabel()
-        ]
-      ];
-
-      if (isset($subtitle[$dependency->getStatus()->getLabel()]) === false) {
-        $subtitle[$dependency->getStatus()->getLabel()] = 0;
+      if ($packageCol->isEmpty()) {
+        throw new PackageNotFoundException();
       }
 
-      $subtitle[$dependency->getStatus()->getLabel()]++;
-    }
+      $package = $packageCol->first();
 
-    if (count($subtitle) === 1 && isset($subtitle[DependencyStatusEnum::UpToDate->getLabel()])) {
-      $data['requiredDepsSubtitle'] = 'all up-to-date';
-    } else {
-      ksort($subtitle);
-      $data['requiredDepsSubtitle'] = implode(
-        ', ',
-        array_filter(
-          array_map(
-            static function (string $key, int $value): string {
-              return match (DependencyStatusEnum::tryFrom($key)) {
-                DependencyStatusEnum::Unknown       => "{$value} unknown",
-                DependencyStatusEnum::Outdated      => "{$value} outdated",
-                DependencyStatusEnum::Insecure      => "{$value} insecure",
-                DependencyStatusEnum::MaybeInsecure => "{$value} possibly insecure",
-                DependencyStatusEnum::UpToDate      => '', // "{$value} up-to-date"
-                null                                => ''
-              };
-            },
-            array_keys($subtitle),
-            array_values($subtitle)
-          )
-        )
-      );
-    }
-
-    $subtitle = [];
-    foreach ($devDependencies as $dependency) {
-      $packageCol = $this->packageRepository->find(
+      $versionCol = $this->versionRepository->find(
         [
-          'name' => $dependency->getName()
+          'package_id' => $package->getId(),
+          'number'     => $version
         ],
         1
       );
 
-      // handle unregistered dependencies
-      $unregistered = $packageCol->isEmpty();
-      $dependencyPackage = match ($packageCol->isEmpty()) {
-        true  => [
-          'name' => $dependency->getName()
-        ],
-        false => $packageCol->first()
-      };
+      if ($versionCol->isEmpty()) {
+        throw new VersionNotFoundException(
+          sprintf(
+            'Version "%s" was not found. Was that release tagged?',
+            $version
+          )
+        );
+      }
 
-      $data['requiredDevDeps'][] = [
-        'package' => $dependencyPackage,
-        'requiredVersion' => $dependency->getConstraint(),
-        'unregistered' => $unregistered,
+      $release = $versionCol->first();
+
+      $reqDependencies = $this->dependencyRepository->find(
+        [
+          'version_id'  => $release->getId(),
+          'development' => false
+        ]
+      );
+
+      $devDependencies = $this->dependencyRepository->find(
+        [
+          'version_id'  => $release->getId(),
+          'development' => true
+        ]
+      );
+
+      $data = [
         'status' => [
-          'type' => $dependency->getStatus()->getColor(),
-          'text' => $dependency->getStatus()->getLabel()
+          'type' => ''
+        ],
+        'package' => $package,
+        'version' => $release,
+        'requiredDeps' => [],
+        'requiredDepsSubtitle' => '',
+        'requiredDevDeps' => [],
+        'requiredDevDepsSubtitle' => '',
+        'show' => [
+          'hero' => [
+            'footer' => true,
+          ],
+          'navbar' => [
+            'menu' => true
+          ]
+        ],
+        'app' => [
+          'version' => $_ENV['VERSION']
         ]
       ];
 
-      if (isset($subtitle[$dependency->getStatus()->getLabel()]) === false) {
-        $subtitle[$dependency->getStatus()->getLabel()] = 0;
+      $data['status']['type'] = match ($release->getStatus()) {
+        VersionStatusEnum::UpToDate => 'is-success',
+        VersionStatusEnum::NoDeps => 'is-success',
+        VersionStatusEnum::Outdated => 'is-warning',
+        VersionStatusEnum::Insecure => 'is-danger',
+        VersionStatusEnum::MaybeInsecure => 'is-warning',
+        VersionStatusEnum::Unknown => 'is-dark'
+      };
+
+      $subtitle = [];
+      foreach ($reqDependencies as $dependency) {
+        $packageCol = $this->packageRepository->find(
+          [
+            'name' => $dependency->getName()
+          ],
+          1
+        );
+
+        // handle unregistered dependencies
+        $unregistered = $packageCol->isEmpty();
+        $dependencyPackage = match ($packageCol->isEmpty()) {
+          true  => [
+            'name' => $dependency->getName()
+          ],
+          false => $packageCol->first()
+        };
+
+        $data['requiredDeps'][] = [
+          'package' => $dependencyPackage,
+          'requiredVersion' => $dependency->getConstraint(),
+          'unregistered' => $unregistered,
+          'status' => [
+            'type' => $dependency->getStatus()->getColor(),
+            'text' => $dependency->getStatus()->getLabel()
+          ]
+        ];
+
+        if (isset($subtitle[$dependency->getStatus()->getLabel()]) === false) {
+          $subtitle[$dependency->getStatus()->getLabel()] = 0;
+        }
+
+        $subtitle[$dependency->getStatus()->getLabel()]++;
       }
 
-      $subtitle[$dependency->getStatus()->getLabel()]++;
-    }
-
-    if (count($subtitle) === 1 && isset($subtitle[DependencyStatusEnum::UpToDate->getLabel()])) {
-      $data['requiredDevDepsSubtitle'] = 'all up-to-date';
-    } else {
-      ksort($subtitle);
-      $data['requiredDevDepsSubtitle'] = implode(
-        ', ',
-        array_filter(
-          array_map(
-            static function (string $key, int $value): string {
-              return match (DependencyStatusEnum::tryFrom($key)) {
-                DependencyStatusEnum::Unknown       => "{$value} unknown",
-                DependencyStatusEnum::Outdated      => "{$value} outdated",
-                DependencyStatusEnum::Insecure      => "{$value} insecure",
-                DependencyStatusEnum::MaybeInsecure => "{$value} maybe insecure",
-                DependencyStatusEnum::UpToDate      => '', //"{$value} up-to-date"
-                null                                => ''
-              };
-            },
-            array_keys($subtitle),
-            array_values($subtitle)
+      if (count($subtitle) === 1 && isset($subtitle[DependencyStatusEnum::UpToDate->getLabel()])) {
+        $data['requiredDepsSubtitle'] = 'all up-to-date';
+      } else {
+        ksort($subtitle);
+        $data['requiredDepsSubtitle'] = implode(
+          ', ',
+          array_filter(
+            array_map(
+              static function (string $key, int $value): string {
+                return match (DependencyStatusEnum::tryFrom($key)) {
+                  DependencyStatusEnum::Unknown       => "{$value} unknown",
+                  DependencyStatusEnum::Outdated      => "{$value} outdated",
+                  DependencyStatusEnum::Insecure      => "{$value} insecure",
+                  DependencyStatusEnum::MaybeInsecure => "{$value} possibly insecure",
+                  DependencyStatusEnum::UpToDate      => '', // "{$value} up-to-date"
+                  null                                => ''
+                };
+              },
+              array_keys($subtitle),
+              array_values($subtitle)
+            )
           )
-        )
-      );
-    }
+        );
+      }
 
-    return $this->respondWithHtml(
-      $twig->fetch(
+      $subtitle = [];
+      foreach ($devDependencies as $dependency) {
+        $packageCol = $this->packageRepository->find(
+          [
+            'name' => $dependency->getName()
+          ],
+          1
+        );
+
+        // handle unregistered dependencies
+        $unregistered = $packageCol->isEmpty();
+        $dependencyPackage = match ($packageCol->isEmpty()) {
+          true  => [
+            'name' => $dependency->getName()
+          ],
+          false => $packageCol->first()
+        };
+
+        $data['requiredDevDeps'][] = [
+          'package' => $dependencyPackage,
+          'requiredVersion' => $dependency->getConstraint(),
+          'unregistered' => $unregistered,
+          'status' => [
+            'type' => $dependency->getStatus()->getColor(),
+            'text' => $dependency->getStatus()->getLabel()
+          ]
+        ];
+
+        if (isset($subtitle[$dependency->getStatus()->getLabel()]) === false) {
+          $subtitle[$dependency->getStatus()->getLabel()] = 0;
+        }
+
+        $subtitle[$dependency->getStatus()->getLabel()]++;
+      }
+
+      if (count($subtitle) === 1 && isset($subtitle[DependencyStatusEnum::UpToDate->getLabel()])) {
+        $data['requiredDevDepsSubtitle'] = 'all up-to-date';
+      } else {
+        ksort($subtitle);
+        $data['requiredDevDepsSubtitle'] = implode(
+          ', ',
+          array_filter(
+            array_map(
+              static function (string $key, int $value): string {
+                return match (DependencyStatusEnum::tryFrom($key)) {
+                  DependencyStatusEnum::Unknown       => "{$value} unknown",
+                  DependencyStatusEnum::Outdated      => "{$value} outdated",
+                  DependencyStatusEnum::Insecure      => "{$value} insecure",
+                  DependencyStatusEnum::MaybeInsecure => "{$value} maybe insecure",
+                  DependencyStatusEnum::UpToDate      => '', //"{$value} up-to-date"
+                  null                                => ''
+                };
+              },
+              array_keys($subtitle),
+              array_values($subtitle)
+            )
+          )
+        );
+      }
+
+      $this->logger->debug("Package '{$vendor}/{$project}:{$version}' was rendered.");
+      $html = $twig->fetch(
         'package/view.twig',
         $data
-      )
+      );
+
+      $item->set($html);
+      $item->expiresAfter(3600);
+
+      $this->cacheItemPool->save($item);
+    }
+
+    $this->logger->debug("Package '{$vendor}/{$project}:{$version}' was viewed.");
+    $this->response = $this->cacheProvider->withEtag(
+      $this->response,
+      hash('sha1', $html)
     );
+
+    return $this->respondWithHtml($html);
   }
 }

--- a/src/Application/Action/Package/ViewPackageBadgeAction.php
+++ b/src/Application/Action/Package/ViewPackageBadgeAction.php
@@ -12,6 +12,7 @@ use PackageHealth\PHP\Domain\Package\PackageValidator;
 use PackageHealth\PHP\Domain\Version\VersionRepositoryInterface;
 use PackageHealth\PHP\Domain\Version\VersionStatusEnum;
 use PackageHealth\PHP\Domain\Version\VersionValidator;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use PUGX\Poser\Poser;
@@ -25,12 +26,13 @@ final class ViewPackageBadgeAction extends AbstractPackageAction {
   public function __construct(
     LoggerInterface $logger,
     CacheProvider $cacheProvider,
+    CacheItemPoolInterface $cacheItemPool,
     PackageRepositoryInterface $packageRepository,
     Poser $poser,
     VersionRepositoryInterface $versionRepository,
     DependencyRepositoryInterface $dependencyRepository
   ) {
-    parent::__construct($logger, $cacheProvider, $packageRepository);
+    parent::__construct($logger, $cacheProvider, $cacheItemPool, $packageRepository);
 
     $this->poser                = $poser;
     $this->versionRepository    = $versionRepository;
@@ -47,104 +49,122 @@ final class ViewPackageBadgeAction extends AbstractPackageAction {
     $version = $this->resolveStringArg('version');
     VersionValidator::assertValid($version);
 
-    $packageCol = $this->packageRepository->find(
-      [
-        'name' => "{$vendor}/{$project}"
-      ],
-      1
-    );
+    $item  = $this->cacheItemPool->getItem("/view/viewPackageBadge/{$vendor}/{$project}/{$version}");
+    $badge = $item->get();
+    if ($item->isHit() === false) {
+      $packageCol = $this->packageRepository->find(
+        [
+          'name' => "{$vendor}/{$project}"
+        ],
+        1
+      );
 
-    if ($packageCol->isEmpty()) {
-      throw new PackageNotFoundException();
+      if ($packageCol->isEmpty()) {
+        throw new PackageNotFoundException();
+      }
+
+      $package = $packageCol->first();
+      $versionCol = $this->versionRepository->find(
+        [
+          'package_id' => $package->getId(),
+          'number'     => $version
+        ],
+        1
+      );
+
+      if ($versionCol->isEmpty()) {
+        $this->logger->debug("Status badge for package '{$vendor}/{$project}:{$version}' was rendered.");
+        $badge = (string)$this->poser->generate(
+          'dependencies',
+          'unknown',
+          'lightgrey',
+          'flat-square'
+        );
+        $this->response = $this->cacheProvider->withEtag(
+          $this->response,
+          hash('sha1', $badge)
+        );
+        return $this->respondWith('image/svg+xml', $badge);
+      }
+
+      $release = $versionCol->first();
+
+      $status = [
+        'text'  => 'unknown',
+        'color' => 'lightgrey'
+      ];
+      switch ($release->getStatus()) {
+        case VersionStatusEnum::UpToDate:
+          $status = [
+            'text'  => 'up-to-date',
+            'color' => 'brightgreen'
+          ];
+          break;
+
+        case VersionStatusEnum::Outdated:
+          $dependencyCol = $this->dependencyRepository->find(
+            [
+              'version_id'  => $release->getId(),
+              'development' => false
+            ]
+          );
+
+          $outdated = count($dependencyCol->filter(
+            static function (Dependency $dependency): bool {
+              return $dependency->getStatus() === DependencyStatusEnum::Outdated;
+            }
+          ));
+
+          $total = count($dependencyCol);
+
+          $status = [
+            'text'  => "{$outdated} of {$total} outdated",
+            'color' => 'yellow'
+          ];
+          break;
+
+        case VersionStatusEnum::Insecure:
+          $status = [
+            'text'  => 'insecure',
+            'color' => 'red'
+          ];
+          break;
+
+        case VersionStatusEnum::MaybeInsecure:
+          $status = [
+            'text'  => 'maybe insecure',
+            'color' => 'orange'
+          ];
+          break;
+
+        case VersionStatusEnum::NoDeps:
+          $status = [
+            'text'  => 'none',
+            'color' => 'blue'
+          ];
+          break;
+      }
+
+      $this->logger->debug("Status badge for package '{$vendor}/{$project}:{$version}' was rendered.");
+      $badge = (string)$this->poser->generate(
+        'dependencies',
+        $status['text'],
+        $status['color'],
+        'flat-square'
+      );
+
+      $item->set($badge);
+      $item->expiresAfter(3600);
+
+      $this->cacheItemPool->save($item);
     }
 
-    $this->logger->debug("Status badge for package '{$vendor}/{$project}' was viewed.");
-
-    $package = $packageCol->first();
-    $versionCol = $this->versionRepository->find(
-      [
-        'package_id' => $package->getId(),
-        'number'     => $version
-      ],
-      1
-    );
-
-    if ($versionCol->isEmpty()) {
-      $badge = $this->poser->generate('dependencies', 'unknown', 'lightgrey', 'flat-square');
-
-      return $this->respondWith('image/svg+xml', (string)$badge);
-    }
-
-    $lastModified = $package->getUpdatedAt() ?? $package->getCreatedAt();
-    $this->response = $this->cacheProvider->withLastModified(
-      $this->response,
-      $lastModified->getTimestamp()
-    );
+    $this->logger->debug("Status badge for package '{$vendor}/{$project}:{$version}' was viewed.");
     $this->response = $this->cacheProvider->withEtag(
       $this->response,
-      hash('sha1', (string)$lastModified->getTimestamp())
+      hash('sha1', $badge)
     );
 
-    $release = $versionCol->first();
-
-    $status = [
-      'text'  => 'unknown',
-      'color' => 'lightgrey'
-    ];
-    switch ($release->getStatus()) {
-      case VersionStatusEnum::UpToDate:
-        $status = [
-          'text'  => 'up-to-date',
-          'color' => 'brightgreen'
-        ];
-        break;
-
-      case VersionStatusEnum::Outdated:
-        $dependencyCol = $this->dependencyRepository->find(
-          [
-            'version_id'  => $release->getId(),
-            'development' => false
-          ]
-        );
-
-        $outdated = count($dependencyCol->filter(
-          static function (Dependency $dependency): bool {
-            return $dependency->getStatus() === DependencyStatusEnum::Outdated;
-          }
-        ));
-
-        $total = count($dependencyCol);
-
-        $status = [
-          'text'  => "{$outdated} of {$total} outdated",
-          'color' => 'yellow'
-        ];
-        break;
-
-      case VersionStatusEnum::Insecure:
-        $status = [
-          'text'  => 'insecure',
-          'color' => 'red'
-        ];
-        break;
-
-      case VersionStatusEnum::MaybeInsecure:
-        $status = [
-          'text'  => 'maybe insecure',
-          'color' => 'orange'
-        ];
-        break;
-
-      case VersionStatusEnum::NoDeps:
-        $status = [
-          'text'  => 'none',
-          'color' => 'blue'
-        ];
-        break;
-    }
-
-    $badge = $this->poser->generate('dependencies', $status['text'], $status['color'], 'flat-square');
-
-    return $this->respondWith('image/svg+xml', (string)$badge);
+    return $this->respondWith('image/svg+xml', $badge);
   }
 }


### PR DESCRIPTION
This PR adds action output caching.

Note that this PR also removes `Last-Modified` response headers as both `Last-Modified` and `ETag` headers are considered "weak caching headers" and therefore makes no sense to have both.

Reference: [which-one-to-use-expire-header-last-modified-header-or-etags](https://stackoverflow.com/questions/5321876/which-one-to-use-expire-header-last-modified-header-or-etags)